### PR TITLE
refs #TECH: update drone-git base image to upgrade git to v2.24

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.11
 RUN apk add --no-cache ca-certificates git git-lfs openssh curl perl
 
 ADD posix/* /usr/local/bin/


### PR DESCRIPTION
### Relevant commits/breaking changes

  - update drone-git base image to upgrade git to v2.24